### PR TITLE
Fix incorrect urls used when pypi_name or conda_package are set.

### DIFF
--- a/python/build.py
+++ b/python/build.py
@@ -89,7 +89,8 @@ for section in config:
         if 'pypi' in package['badges']:
             needs_newline = True
             print('    pypi: ', end='', flush=True)
-            response = requests.get(f"http://pypi.python.org/pypi/{package['name']}/json/")
+            response = requests.get(
+                f"http://pypi.python.org/pypi/{package['pypi_name']}/json/")
             if response.status_code == 200:
                 print('found')
             else:
@@ -102,7 +103,9 @@ for section in config:
         if 'conda' in package['badges']:
             needs_newline = True
             print('    conda: ', end='')
-            response = requests.get(f"https://anaconda.org/{package['conda_channel']}/{package['name']}/", allow_redirects=False)
+            response = requests.get(
+                f"https://anaconda.org/{package['conda_channel']}/{package['conda_package']}/",
+                allow_redirects=False)
             if response.status_code == 200:
                 print('found', end='')
             else:


### PR DESCRIPTION
See e.g. pyupset, which was not correctly resolved previously.

Goes on top of https://github.com/matplotlib/mpl-third-party/pull/26.

<!--
To create a new package yml, make a new file with your package name in the `packages/`
directory with a  yml suffix.  Examples can be seen in the `packages/` directory, but 
at the minimum you need to include the `repo:`, `section:` and `description:` fields.  
Please keep the description very short.  

Other useful fields are `site:`, `pypi_name`, `conda_package`, (if different from the 
github name), and `conda_channel` if not *conda-forge*.  
-->
