### PR TITLE
adding to yaml template

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,20 @@
 
 List of matplotlib user-contributed packages.  These are served at http://matplotlib.org/mpl-third-party/
 
-To add your package to the list create a YAML file `your-cool-mpl-package.yml` with the following fields:
+To add your package to the list, create a YAML file `your-cool-mpl-package.yml` with the following fields:
 
 ```yml
 repo: matplotlib/cmocean
 site: https://matplotlib.org/cmocean/
 keywords:  colormaps
 description:  Preceptually uniform colormaps for commonly-used oceanographic variables
+pypi_name: # optional, default repo name
+conda_package: # optional
+conda_channel: # optional
 ```
+Either fork this repo and add the new file to the `packages` directory, or use the `Add File` button above, and then create a PR.
 
-Other descriptors can be `pypi_name`, `conda_package`, and `conda_channel`. 
-`pypi_name` will automatically fill with the repo name if `pypi_name` is not supplied.  
-
-Either fork this repo and add the new file to the `packages` directory,
-or use the `Add File` button above, and then create a PR.
-
-Note that the name of the yml and the name of the repo should ideally match.
+Note: The name of the yml file and the name of the repo should ideally match.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ pypi_name: # optional, default repo name
 conda_package: # optional
 conda_channel: # optional, default conda-forge
 ```
-Either fork this repo and add the new file to the `packages` directory, or use the `Add File` button above, and then create a PR.
+Either fork this repo and add the new file to the `packages` directory, 
+or use the `Add File` button above, and then create a PR.
 
 Note: The name of the yml file and the name of the repo should ideally match.
 
@@ -24,5 +25,4 @@ the result is saved to `docs/source/packages.rst`.  This script is called by `do
 using `make html`.  This runs a `sphinx-build` and makes the page at `build/html/index.html`.  
 
 This was heavily based on the nice work at <https://pyviz.org>.  
-
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ keywords:  colormaps
 description:  Preceptually uniform colormaps for commonly-used oceanographic variables
 pypi_name: # optional, default repo name
 conda_package: # optional
-conda_channel: # optional
+conda_channel: # optional, default conda-forge
 ```
 Either fork this repo and add the new file to the `packages` directory, or use the `Add File` button above, and then create a PR.
 
@@ -24,6 +24,5 @@ the result is saved to `docs/source/packages.rst`.  This script is called by `do
 using `make html`.  This runs a `sphinx-build` and makes the page at `build/html/index.html`.  
 
 This was heavily based on the nice work at <https://pyviz.org>.  
-
 
 

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -3,8 +3,7 @@ and distributed independently from Matplotlib so go to the website
 listed for instructions.  
 
 Please contribute your package by opening a pull-request at 
-https://github.com/matplotlib/mpl-third-party and create a new yml
-file from the template there and we will add you to the list.  
+https://github.com/matplotlib/mpl-third-party using the template in the `readme <https://github.com/matplotlib/mpl-third-party>`_
 
 If you need help making a package, see 
 https://github.com/matplotlib/matplotlib-extension-cookiecutter

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -3,7 +3,8 @@ and distributed independently from Matplotlib so go to the website
 listed for instructions.  
 
 Please contribute your package by opening a pull-request at 
-https://github.com/matplotlib/mpl-third-party using the template in the `readme <https://github.com/matplotlib/mpl-third-party>`_
+https://github.com/matplotlib/mpl-third-party using the template in the
+`readme <https://github.com/matplotlib/mpl-third-party>`_
 
 If you need help making a package, see 
 https://github.com/matplotlib/matplotlib-extension-cookiecutter


### PR DESCRIPTION
Really, would like to factor out the template into a standalone file, but markdown won't natively support an embed. (But there's a github action for it). Instead, expanding the template in the readme and linking to it from the intro