### PR TITLE
recategorized speciality and misc

### DIFF
--- a/packages/DnaFeaturesViewer.yml
+++ b/packages/DnaFeaturesViewer.yml
@@ -1,5 +1,5 @@
 repo: Edinburgh-Genome-Foundry/DnaFeaturesViewer
-section: miscellaneous
+section: domain specific libraries
 description: Visualize DNA features, e.g. from GenBank or Gff files, or Biopython SeqRecords.
 site: https://edinburgh-genome-foundry.github.io/DnaFeaturesViewer/
 pypi_name: dna-features-viewer

--- a/packages/adjustText.yml
+++ b/packages/adjustText.yml
@@ -1,3 +1,3 @@
 repo: Phlya/adjustText
-section: miscellaneous
+section: plotting utilities
 description: Draw many text artists so that they do not overlap.

--- a/packages/astropy.yml
+++ b/packages/astropy.yml
@@ -1,4 +1,4 @@
 repo: astropy/astropy
-section: specialty plots
+section: domain specific library
 description: Astronomy processing and graphics (including mapping).
 site: https://www.astropy.org

--- a/packages/astropy.yml
+++ b/packages/astropy.yml
@@ -1,4 +1,4 @@
 repo: astropy/astropy
-section: domain specific library
+section: domain specific libraries
 description: Astronomy processing and graphics (including mapping).
 site: https://www.astropy.org

--- a/packages/blume.yml
+++ b/packages/blume.yml
@@ -1,3 +1,3 @@
 repo: swfiua/blume
-section: miscellaneous
+section: plot types
 description: Alternate table artist.

--- a/packages/brokenaxes.yml
+++ b/packages/brokenaxes.yml
@@ -1,5 +1,5 @@
 repo: bendichter/brokenaxes
 keywords: axes
-section: specialty plots
+section: plotting utilities
 description: Plots with breaks in the axes.
 conda_channel: conda-forge

--- a/packages/figpager.yml
+++ b/packages/figpager.yml
@@ -1,3 +1,3 @@
 repo: ebenp/figpager
-section: miscellaneous
+section: plotting utilities
 description: Save plots with single or multiple pages.

--- a/packages/grid-strategy.yml
+++ b/packages/grid-strategy.yml
@@ -1,3 +1,3 @@
 repo: matplotlib/grid-strategy
-section: miscellaneous
+section: plotting utilities
 description: Create a grid of subplots based on the number of axes to be plotted.

--- a/packages/matplotlib-scalebar.yml
+++ b/packages/matplotlib-scalebar.yml
@@ -1,4 +1,4 @@
 repo: ppinard/matplotlib-scalebar
-section: specialty plots
+section: plotting utilities
 description: Display a scale bar. 
 conda_channel: conda-forge

--- a/packages/matplotlib-venn.yml
+++ b/packages/matplotlib-venn.yml
@@ -1,5 +1,5 @@
 repo: konstantint/matplotlib-venn
 keywords: diagrams
-section: plot type
+section: plot types
 description: Plotting area-weighted two- and three-circle venn diagrams.
 

--- a/packages/matplotlib-venn.yml
+++ b/packages/matplotlib-venn.yml
@@ -1,5 +1,5 @@
 repo: konstantint/matplotlib-venn
 keywords: diagrams
-section: specialty plots
+section: plot type
 description: Plotting area-weighted two- and three-circle venn diagrams.
 

--- a/packages/mpl-probscale.yml
+++ b/packages/mpl-probscale.yml
@@ -1,7 +1,7 @@
 repo: matplotlib/mpl-probscale
 site: https://matplotlib.org/mpl-probscale/
 keywords: scales
-section: specialty plots
+section: plotting utilities
 description: Real probability scales for matplotlib.
 pypi_name: probscale
 conda_channel: conda-forge

--- a/packages/mpl-template.yml
+++ b/packages/mpl-template.yml
@@ -1,4 +1,4 @@
 repo: austinorr/mpl-template
-section: miscellaneous
+section: plotting utilities
 description: Templating engine for consistent plots.
 site: https://austinorr.github.io/mpl-template/

--- a/packages/mplfinance.yml
+++ b/packages/mplfinance.yml
@@ -1,3 +1,3 @@
 repo: matplotlib/mplfinance
-section: specialty plots
+section: domain specific library
 description: Utilities for the visual analysis of financial data.

--- a/packages/mplfinance.yml
+++ b/packages/mplfinance.yml
@@ -1,3 +1,3 @@
 repo: matplotlib/mplfinance
-section: domain specific library
+section: domain specific libraries
 description: Utilities for the visual analysis of financial data.

--- a/packages/mplstereonet.yml
+++ b/packages/mplstereonet.yml
@@ -1,3 +1,3 @@
 repo: joferkington/mplstereonet
-section: specialty plots
+section: mapping
 description: Lower-hemisphere equal-area and equal-angle stereonets.

--- a/packages/plotnine.yml
+++ b/packages/plotnine.yml
@@ -1,0 +1,4 @@
+repo: https://github.com/has2k1/plotnine
+section: domain specific library
+site: https://plotnine.readthedocs.io/en/latest/
+description: a grammar of graphics for Python

--- a/packages/plotnine.yml
+++ b/packages/plotnine.yml
@@ -1,4 +1,4 @@
 repo: https://github.com/has2k1/plotnine
-section: domain specific library
+section: domain specific libraries
 site: https://plotnine.readthedocs.io/en/latest/
 description: a grammar of graphics for Python

--- a/packages/plotnine.yml
+++ b/packages/plotnine.yml
@@ -1,4 +1,4 @@
-repo: https://github.com/has2k1/plotnine
+repo: has2k1/plotnine
 section: domain specific libraries
-site: https://plotnine.readthedocs.io/en/latest/
 description: a grammar of graphics for Python
+site: https://plotnine.readthedocs.io/en/latest/

--- a/packages/pyupset.yml
+++ b/packages/pyupset.yml
@@ -1,4 +1,4 @@
 repo: ImSoErgodic/py-upset
-section: specialty plots
-description: UpSet suite of visualisation methods.
+section: plot types
+description: UpSet suite of visualization methods.
 pypi_name: pyupset

--- a/packages/seaborn.yml
+++ b/packages/seaborn.yml
@@ -1,4 +1,4 @@
 repo: mwaskom/seaborn
-section: domain specific library
+section: domain specific libraries
 description: High-level interface for drawing attractive statistical graphics.
 site: https://seaborn.pydata.org

--- a/packages/seaborn.yml
+++ b/packages/seaborn.yml
@@ -1,4 +1,4 @@
 repo: mwaskom/seaborn
-section: specialty plots
+section: domain specific library
 description: High-level interface for drawing attractive statistical graphics.
 site: https://seaborn.pydata.org

--- a/packages/sphinx-gallery.yml
+++ b/packages/sphinx-gallery.yml
@@ -1,4 +1,4 @@
 repo: sphinx-gallery/sphinx-gallery
-section: miscellaneous
+section: documentation
 description: Create matplotlib galleries for your sphinx-built documentation.
 site: https://sphinx-gallery.github.io/stable/

--- a/packages/windrose.yml
+++ b/packages/windrose.yml
@@ -1,3 +1,3 @@
 repo: scls19fr/windrose
-section: plot type
+section: plot types
 description: Create windrose plots.

--- a/packages/windrose.yml
+++ b/packages/windrose.yml
@@ -1,3 +1,3 @@
 repo: scls19fr/windrose
-section: specialty plots
+section: plot type
 description: Create windrose plots.

--- a/packages/yellowbrick.yml
+++ b/packages/yellowbrick.yml
@@ -1,4 +1,4 @@
 repo: DistrictDataLabs/yellowbrick
-section: domain specific library
+section: domain specific libraries
 site: https://www.scikit-yb.org/en/latest/
 description: Visual analysis and diagnostic tools to facilitate machine learning model selection.

--- a/packages/yellowbrick.yml
+++ b/packages/yellowbrick.yml
@@ -1,4 +1,4 @@
 repo: DistrictDataLabs/yellowbrick
-section: specialty plots
+section: domain specific library
 site: https://www.scikit-yb.org/en/latest/
 description: Visual analysis and diagnostic tools to facilitate machine learning model selection.

--- a/python/build.py
+++ b/python/build.py
@@ -18,15 +18,15 @@ except:
     pass
 packages = glob.glob(os.path.join(here, '../packages/*'))
 
-section_names = {'colormaps and styles': 'Colormaps and Styles', 
-           'plotting utilities': 'Plotting Utilities',
-           'plot types': 'Plot Types', 
-           'gui applications': 'GUI Applications', 
-           'backends': 'Rendering Backends', 
+section_names = {'colormaps and styles': 'Colormaps and styles', 
+           'plotting utilities': 'Plotting utilities',
+           'plot types': 'Plot types', 
+           'gui applications': 'GUI applications', 
+           'backends': 'Rendering backends', 
            'interactivity': 'Interactivity',
            'animations': 'Animations',
            'mapping': 'Mapping', 
-           'domain specific libraries': 'Domain Specific Libraries', 
+           'domain specific libraries': 'Domain specific libraries', 
            'documentation': 'Documentation',
            'miscellaneous': 'Miscellaneous'}
 

--- a/python/build.py
+++ b/python/build.py
@@ -18,15 +18,18 @@ except:
     pass
 packages = glob.glob(os.path.join(here, '../packages/*'))
 
-section_names = {'colormaps and styles': 'Colormaps and styles', 
-           'specialty plots': 'Specialty plots',
-           'gui applications': 'GUI applications', 
-           'miscellaneous': 'Miscellaneous', 
-           'backends': 'Rendering backends', 
+section_names = {'colormaps and styles': 'Colormaps and Styles', 
+           'plotting utilities': 'Plotting Utilities',
+           'plot types': 'Plot Types', 
+           'gui applications': 'GUI Applications', 
+           'backends': 'Rendering Backends', 
            'interactivity': 'Interactivity',
            'animations': 'Animations',
            'mapping': 'Mapping', 
-           'declarative libraries': 'Declarative Libraries'}
+           'domain specific libraries': 'Domain Specific Libraries',
+           'declarative libraries': 'Declarative Libraries', 
+           'documentation': 'Documentation'
+           'miscellaneous': 'Miscellaneous', }
 
 
 packs = dict()

--- a/python/build.py
+++ b/python/build.py
@@ -26,10 +26,9 @@ section_names = {'colormaps and styles': 'Colormaps and Styles',
            'interactivity': 'Interactivity',
            'animations': 'Animations',
            'mapping': 'Mapping', 
-           'domain specific libraries': 'Domain Specific Libraries',
-           'declarative libraries': 'Declarative Libraries', 
-           'documentation': 'Documentation'
-           'miscellaneous': 'Miscellaneous', }
+           'domain specific libraries': 'Domain Specific Libraries', 
+           'documentation': 'Documentation',
+           'miscellaneous': 'Miscellaneous'}
 
 
 packs = dict()


### PR DESCRIPTION
## PR Summary
Removed specialty and recategorized specialty and misc into:
* plotting utilities - adjust text, highlight text, broken axes, etc - not specific to any plot type, general tools
* plot types - plot types not specific to any domain - blume, windrose, venn, etc
* domain specific libraries - astropy, seaborn, mplfinance, etc
* documentation - libs for documenting mpl packages - sphinx gallery, @ianhi 's mpl recorder tool would be useful here too, 

doc could also be renamed to development and be a catch all for libraries for developing mpl packages like sphinx gallery, mpl test, mpl cookie cutter
