### PR TITLE
DOC: readme typo, expanded instructructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ conda_package: # optional
 conda_channel: # optional, default conda-forge
 ```
 Either fork this repo and add the new file to the `packages` directory, 
-or use the `Add File` button above, and then create a PR.
+or use the `Add File` button above. Then open a pull request with the new file.
 
 Note: The name of the yml file and the name of the repo should ideally match.
 
 ## Development
 
-The list if *yml* files in `packages/` is parsed by `build/build.py` using `template.rst` and
+The list of *yml* files in `packages/` is parsed by `build/build.py` using `template.rst` and
 the result is saved to `docs/source/packages.rst`.  This script is called by `docs/Makefile` 
 using `make html`.  This runs a `sphinx-build` and makes the page at `build/html/index.html`.  
 


### PR DESCRIPTION
Added a few more words to the readme commit instructions to make clear either option requires a pull request.
