### PR TITLE
ENH: split section names out of build.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ or use the `Add File` button above. Then open a pull request with the new file.
 
 Note: The name of the yml file and the name of the repo should ideally match.
 
+The `section` entry should be one of the sections listed in <./section_names.yml>.
+
 ## Development
 
 The list of yml files in `packages/` is parsed by `python/build.py` using `template.rst` and

--- a/python/build.py
+++ b/python/build.py
@@ -18,19 +18,15 @@ except:
     pass
 packages = glob.glob(os.path.join(here, '../packages/*'))
 
-section_names = {'colormaps and styles': 'Colormaps and styles', 
-           'plotting utilities': 'Plotting utilities',
-           'plot types': 'Plot types', 
-           'gui applications': 'GUI applications', 
-           'backends': 'Rendering backends', 
-           'interactivity': 'Interactivity',
-           'animations': 'Animations',
-           'mapping': 'Mapping', 
-           'domain specific libraries': 'Domain specific libraries', 
-           'documentation': 'Documentation',
-           'miscellaneous': 'Miscellaneous'}
 
 
+print("Opening section names file")
+with open(os.path.join(here, '../section_names.yml')) as f:
+    section_names = safe_load(f)
+
+section_names = section_names['section_names']
+
+print("section_names", section_names)
 packs = dict()
 # divide the yml files into sections based on teh section tag...
 for package in packages:

--- a/section_names.yml
+++ b/section_names.yml
@@ -1,0 +1,12 @@
+section_names:
+  colormaps and styles: Colormaps and styles
+  plotting utilities: Plotting utilities
+  plot types: Plot types
+  gui applications: GUI applications
+  backends: Rendering backends 
+  interactivity: Interactivity
+  animations: Animations
+  mapping: Mapping
+  domain specific libraries: Domain specific libraries
+  documentation: Documentation
+  miscellaneous: Miscellaneous


### PR DESCRIPTION
## PR Summary

This splits the section names into their own yml. 



<!--
To create a new package yml, make a new file with your package name in the `packages/`
directory with a  yml suffix.  Examples can be seen in the `packages/` directory, but 
at the minimum you need to include the `repo:`, `section:` and `description:` fields.  
Please keep the description very short.  

Other useful fields are `site:`, `pypi_name`, `conda_package`, (if different from the 
github name), and `conda_channel` if not *conda-forge*.  
-->
