### PR TITLE
Remove toctree from template.

### DIFF
--- a/python/template.rst
+++ b/python/template.rst
@@ -1,10 +1,3 @@
-
-.. toctree::
-  {% for section in config %}
-  {{ section.name }}  <./index.html#{{ section.name }}>
-  {% endfor %}
-
-
 .. raw:: html
 
   <div>


### PR DESCRIPTION
## PR Summary

It is no longer visible, and Sphinx warns that it is broken anyway.