### PR TITLE
Add farrow-and-ball

### DIFF
--- a/packages/farrow-and-ball.yml
+++ b/packages/farrow-and-ball.yml
@@ -1,0 +1,5 @@
+repo: vork/farrowandball
+section: colormaps and styles
+description: Color palettes inspired by British paint manufacturer Farrow and Ball
+keywords: styles
+pypi_name:  farrow-and-ball


### PR DESCRIPTION
A library that adds color palettes inspired by British paint manufacturer Farrow and Ball

## PR Summary

Add the farrow-and-ball pypi package
