### PR TITLE
ADD: Adding pyart to the mpl-third-party list.

### DIFF
--- a/packages/pyart.yml
+++ b/packages/pyart.yml
@@ -1,0 +1,8 @@
+repo: ARM-DOE/pyart
+section: domain specific libraries
+description: The Python ARM Radar toolkit, used to analyze and plot weather radar data.
+site: https://github.com/ARM-DOE/pyart
+keywords: radar, weather, climate, mapping, plotting
+pypi_name: arm_pyart
+conda_package: arm_pyart
+conda_channel: conda-forge


### PR DESCRIPTION
## PR Summary

Hello! With discussion on twitter @story645 I added py-art. The only one I wasn't sure on was the sections. We use matplotlib and cartopy for plotting the radar data as well as using matplotlib colormaps for creating CVD friendly colormaps. I can correct if need be. Thanks for your time!
