### PR TITLE
FIX: allow for non-github repos

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,11 +2,16 @@
 
 
 <!--
-To create a new package yml, make a new file with your package name in the `packages/`
-directory with a  yml suffix.  Examples can be seen in the `packages/` directory, but 
-at the minimum you need to include the `repo:`, `section:` and `description:` fields.  
-Please keep the description very short.  
+To create a new package yml, make a new file with your package name in the
+`packages/` directory with a  yml suffix.  Examples can be seen in the
+`packages/` directory, but at the minimum you need to include `repo:` and/or
+`name:` fields, and the `section:` and `description:` fields.
+Please keep the description very short.
 
-Other useful fields are `site:`, `pypi_name`, `conda_package`, (if different from the 
-github name), and `conda_channel` if not *conda-forge*.  
+If you do not supply `name:`, it will be parsed from the `repo:` field.  If you
+do not have a github repo, please leave `repo:` blank and be sure to supply
+`name:`.
+
+Other useful fields are `site:`, `pypi_name`, `conda_package`, (if different from the
+github name), and `conda_channel` if not *conda-forge*.
 -->

--- a/packages/astro-tulips.yml
+++ b/packages/astro-tulips.yml
@@ -1,0 +1,6 @@
+section: domain specific libraries
+description: Visualization of the physics of stars
+site: https://astro-tulips.readthedocs.io/en/latest/
+keywords: astronomy, visualization
+pypi_name: astro-tulips
+name: astro-tulips

--- a/python/template.rst
+++ b/python/template.rst
@@ -16,11 +16,14 @@
 
       {% for package in section.packages %}
       <tr>
-        
         <td>
-          <a href="https://github.com/{{ package.user }}/{{ package.name }}">  
+          {% if 'repo' in package %}
+          <a href="https://github.com/{{ package.repo }}">
             <img src="_static/badges/github-gray.svg">
           </a>
+          {% else %}
+          <img src="_static/badges/pip-empty.svg">
+          {% endif %}
         </td>
 
       {% if 'pypi' in package.badges %}
@@ -43,20 +46,20 @@
       {% else %}
         <td>
           <img src="_static/badges/conda-empty.svg">
-        </td>        
-      {% endif %}  
+        </td>
+      {% endif %}
 
       <td>
-      {% if 'site' in package.badges %} 
+      {% if 'site' in package.badges %}
         <a href="{{ package.site_protocol}}://{{ package.site }}">{{ package.name }}</a>
       {% else %}
         <a href="http://github.com/{{ package.repo }}">{{ package.name }}</a>
       {% endif %}
       </td>
       <td>
-        {{ package.description }}   
-      </td>             
-      
+        {{ package.description }}
+      </td>
+
 
       </tr>
       {% endfor %}


### PR DESCRIPTION
## PR Summary

This now allows packages that do not have a GitHub repo to mostly work.  They still need at least a pipit page.  

The code is a bit tacky, so criticism most welcome.



<!--
To create a new package yml, make a new file with your package name in the `packages/`
directory with a  yml suffix.  Examples can be seen in the `packages/` directory, but 
at the minimum you need to include the `repo:`, `section:` and `description:` fields.  
Please keep the description very short.  

Other useful fields are `site:`, `pypi_name`, `conda_package`, (if different from the 
github name), and `conda_channel` if not *conda-forge*.  
-->
