### PR TITLE
dufte -> matplotx

### DIFF
--- a/packages/dufte.yml
+++ b/packages/dufte.yml
@@ -1,3 +1,0 @@
-repo: nschloe/dufte
-section: colormaps and styles
-description: Clean matplotlib style

--- a/packages/matplotx.yml
+++ b/packages/matplotx.yml
@@ -1,0 +1,6 @@
+repo: nschloe/matplotx
+section: miscellaneous
+description: Useful styles and extensions for Matplotlib
+pypi_name: matplotx
+conda_package: matplotx
+conda_channel: conda-forge


### PR DESCRIPTION
dufte is deprecated and moved into matplotx.