### PR TITLE
Add distinctipy

### DIFF
--- a/packages/distinctipy.yml
+++ b/packages/distinctipy.yml
@@ -1,0 +1,5 @@
+repo: alan-turing-institute/distinctipy
+section: colormaps and styles
+description: Qualitative colormaps of any length, generated to be maximally distinct.
+site: https://distinctipy.readthedocs.io/en/latest/
+keywords: [styles, palettes, colormaps, colorblind, categorical]


### PR DESCRIPTION
## PR Summary

I stumbled across https://github.com/matplotlib/matplotlib/issues/22033 requesting larger qualitative colormaps and saw my package distinctipy (which can be used for this purpose) mentioned in the comments. I'd love for it to be included in the 3rd party list and happy to make any modifications needed for that to happen.
