### PR TITLE
MNT: make sure requirements files match

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,5 @@ jinja2
 markdown
 pyyaml
 sphinx
+pydata-sphinx-theme<0.9.0
 mpl-sphinx-theme


### PR DESCRIPTION
## PR Summary

I think GH actions uses the top-level requirement.txt whereas Circle uses the doc level?  

I find the dizzying places we need to keep requirements files by default pretty annoying.  Ideally there would ne one place, particularly for a doc-only project like this.  

<!--
To create a new package yml, make a new file with your package name in the `packages/`
directory with a  yml suffix.  Examples can be seen in the `packages/` directory, but 
at the minimum you need to include the `repo:`, `section:` and `description:` fields.  
Please keep the description very short.  

Other useful fields are `site:`, `pypi_name`, `conda_package`, (if different from the 
github name), and `conda_channel` if not *conda-forge*.  
-->
