### PR TITLE
ci: Build Sphinx docs manually

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,10 +14,18 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      - name: Make docs builds
-        uses: ammaraskar/sphinx-action@master
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          docs-folder: "docs/"
+          python-version: '3.x'
+
+      - name: Install documentation requirements
+        run: |
+          pip install -r docs/requirements.txt
+
+      - name: Make docs builds
+        run: |
+          make -C docs html
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
## PR Summary

The Sphinx GitHub Action uses an [outdated copy of Sphinx](https://github.com/ammaraskar/sphinx-action/issues/25), so just do the steps ourselves.

Unlike my last attempt at #120, I actually checked that [this worked for the action](https://github.com/QuLogic/mpl-third-party/actions/runs/2632627933) as well.

Fixes #121