### PR TITLE
Added mir_eval and librosa packages

### DIFF
--- a/packages/librosa.yml
+++ b/packages/librosa.yml
@@ -1,0 +1,8 @@
+repo: librosa/librosa
+section: domain specific libraries
+description: Audio signal processing with waveform and spectrogram displays
+site: https://librosa.org/ # optional, default repo site
+keywords: [signals, spectrograms] # optional
+pypi_name: librosa
+conda_package: librosa
+conda_channel: conda-forge

--- a/packages/mir-eval.yml
+++ b/packages/mir-eval.yml
@@ -1,0 +1,8 @@
+repo: craffel/mir_eval
+section: domain specific libraries
+description: Evaluation tools and display helpers for audio annotations
+site: https://craffel.github.io/mir_eval/
+keywords: [music, audio, annotation]
+pypi_name: mir_eval
+conda_package: mir_eval
+conda_channel: conda-forge


### PR DESCRIPTION
## PR Summary

This PR adds package specifications for `librosa` and `mir_eval`.  Neither of these packages are purely display-oriented, but both have display submodules which provide domain-specific interfaces to construct figures with matplotlib.
