### PR TITLE
Add MetPy to 3rd party packages

### DIFF
--- a/packages/metpy.yml
+++ b/packages/metpy.yml
@@ -1,0 +1,5 @@
+repo: Unidata/MetPy
+site: https://unidata.github.io/MetPy
+section: domain specific libraries
+keywords: [meteorology, atmospheric science]
+description: A Python toolkit for meteorological applications


### PR DESCRIPTION
## PR Summary
Add MetPy as a 3rd party package.

<!--
To create a new package yml, make a new file with your package name in the `packages/`
directory with a  yml suffix.  Examples can be seen in the `packages/` directory, but 
at the minimum you need to include the `repo:`, `section:` and `description:` fields.  
Please keep the description very short.  

Other useful fields are `site:`, `pypi_name`, `conda_package`, (if different from the 
github name), and `conda_channel` if not *conda-forge*.  
-->
