### PR TITLE
Create mpl-widget-box.yaml

### DIFF
--- a/packages/mpl-widget-box.yaml
+++ b/packages/mpl-widget-box.yaml
@@ -1,5 +1,5 @@
 repo: leejjoon/mpl_widget_box
 keywords: [widgets]
 section: interactivity
-description: GUI-neutral widgets for Matplotlib w/ legend-like layout and more
+description: GUI-neutral widgets for Matplotlib, with legend-like layout and more.
 site: https://mpl-widget-box.readthedocs.io

--- a/packages/mpl-widget-box.yaml
+++ b/packages/mpl-widget-box.yaml
@@ -1,0 +1,5 @@
+repo: leejjoon/mpl_widget_box
+keywords: [widgets]
+section: interactivity
+description: Another gui-neutral widgets for matplotlib
+site: https://mpl-widget-box.readthedocs.io

--- a/packages/mpl-widget-box.yaml
+++ b/packages/mpl-widget-box.yaml
@@ -1,5 +1,5 @@
 repo: leejjoon/mpl_widget_box
 keywords: [widgets]
 section: interactivity
-description: Another gui-neutral widgets for matplotlib
+description: GUI-neutral widgets for Matplotlib w/ legend-like layout and more
 site: https://mpl-widget-box.readthedocs.io


### PR DESCRIPTION
[mpl-widget-box](https://github.com/leejjoon/mpl_widget_box) is a gui-neutral widgets for matplotlib with a legend-like layout.

While still in development and documentation is sparse, Most of the functionality is there and should be usable.

