### PR TITLE
added `framework :: matplotlib` to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The `section` entry should be one of the sections listed in
 [./section_names.yml](https://github.com/matplotlib/mpl-third-party/blob/main/section_names.yml).
 
 ### PyPI Classifier
-Please add the `Framework :: Matplotlib` PyPI Trove classifier to your package's [setup configuration](https://packaging.python.org/en/latest/tutorials/packaging-projects/#configuring-metadata) to be included in a listing of [Matplotlib related projects](https://pypi.org/search/?c=Framework+%3A%3A+Matplotlib) on PyPI, 
+Please add the `Framework :: Matplotlib` PyPI Trove classifier to your package's [setup configuration](https://packaging.python.org/en/latest/tutorials/packaging-projects/#configuring-metadata) to be included in a listing of [Matplotlib related projects](https://pypi.org/search/?c=Framework+%3A%3A+Matplotlib) on PyPI.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Note: The name of the yml file and the name of the repo should ideally match.
 The `section` entry should be one of the sections listed in 
 [./section_names.yml](https://github.com/matplotlib/mpl-third-party/blob/main/section_names.yml).
 
+### PyPI Classifier
+Please add the `Framework :: Matplotlib` PyPI Trove classifier to your package's [setup configuration](https://packaging.python.org/en/latest/tutorials/packaging-projects/#configuring-metadata) to be included in a listing of [Matplotlib related projects](https://pypi.org/search/?c=Framework+%3A%3A+Matplotlib) on PyPI, 
+
 ## Development
 
 The list of yml files in `packages/` is parsed by `python/build.py` using `template.rst` and


### PR DESCRIPTION
In the [last version](https://matplotlib.org/3.4.3/thirdpartypackages/index.html) of the third party docs, we had a sentence about the trove classifier 

> To be included in the PyPI listing, please include Framework :: Matplotlib in the classifier list in the setup.py file for your package. 

that we didn't port over. It's a little awkward here, but this is probably the best place to put the information for the audience of people we want to use it.
