### PR TITLE
Add explicit name attribute to all packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ To add your package to the list, create a YAML file `your-cool-mpl-package.yml` 
 directory. The file must have the following fields:
 
 ```yml
+name: cmocean
 repo: matplotlib/cmocean
 section: colormaps and styles
 description: Perceptually uniform colormaps for oceanographic variables.

--- a/packages/DnaFeaturesViewer.yml
+++ b/packages/DnaFeaturesViewer.yml
@@ -1,3 +1,4 @@
+name: DNA Features Viewer
 repo: Edinburgh-Genome-Foundry/DnaFeaturesViewer
 section: domain specific libraries
 description: Visualize DNA features, e.g. from GenBank or Gff files, or Biopython SeqRecords.

--- a/packages/PyNanoLab.yml
+++ b/packages/PyNanoLab.yml
@@ -1,3 +1,4 @@
+name: PyNanoLab
 repo: decacent/PyNanoLab
 section: gui applications
 description:  PySide6 GUI for data analysis and visualisation with matplotlib and pandas.

--- a/packages/PySimpleGUI.yml
+++ b/packages/PySimpleGUI.yml
@@ -1,3 +1,4 @@
+name: PySimpleGUI
 repo: PySimpleGUI/PySimpleGUI
 section: gui applications
 description: Create custom GUIs quickly & easily on top of tkinter, Qt, WxPython or Remi.

--- a/packages/adjustText.yml
+++ b/packages/adjustText.yml
@@ -1,3 +1,4 @@
+name: adjustText
 repo: Phlya/adjustText
 section: plotting utilities
 description: Draw many text artists so that they do not overlap.

--- a/packages/animatplot.yml
+++ b/packages/animatplot.yml
@@ -1,3 +1,4 @@
+name: animatplot
 repo: t-makaro/animatplot
 keywords: [animations, gif, jupyter]
 section: animations

--- a/packages/aquarel.yml
+++ b/packages/aquarel.yml
@@ -1,3 +1,4 @@
+name: Aquarel
 repo: lgienapp/aquarel
 section: colormaps and styles
 description: Simplified wrapper for flexible styling and theming. 

--- a/packages/arviz.yml
+++ b/packages/arviz.yml
@@ -1,3 +1,4 @@
+name: ArviZ
 repo: arviz-devs/arviz
 section: domain specific libraries
 description: Exploratory analysis of Bayesian models with Python.

--- a/packages/astropy.yml
+++ b/packages/astropy.yml
@@ -1,3 +1,4 @@
+name: Astropy
 repo: astropy/astropy
 section: domain specific libraries
 description: Astronomy processing and graphics (including mapping).

--- a/packages/bgheatmaps.yaml
+++ b/packages/bgheatmaps.yaml
@@ -1,3 +1,4 @@
+name: BG Heatmaps
 repo: brainglobe/bg-heatmaps
 section: domain specific libraries
 description: Brain heatmaps visualization.

--- a/packages/blume.yml
+++ b/packages/blume.yml
@@ -1,3 +1,4 @@
+name: Blume
 repo: swfiua/blume
 section: plot types
 description: Alternate table artist.

--- a/packages/brokenaxes.yml
+++ b/packages/brokenaxes.yml
@@ -1,3 +1,4 @@
+name: brokenaxes
 repo: bendichter/brokenaxes
 keywords: [axes]
 section: plotting utilities

--- a/packages/cartopy.yml
+++ b/packages/cartopy.yml
@@ -1,3 +1,4 @@
+name: cartopy
 repo: SciTools/cartopy
 site: https://scitools.org.uk/cartopy
 keywords: [mapping, geospatial, projections]

--- a/packages/celluloid.yml
+++ b/packages/celluloid.yml
@@ -1,3 +1,4 @@
+name: celluloid
 repo: jwkvam/celluloid
 section: animations
 description: Matplotlib animations made easy.

--- a/packages/cmasher.yml
+++ b/packages/cmasher.yml
@@ -1,3 +1,4 @@
+name: CMasher
 repo: 1313e/CMasher
 site: https://cmasher.readthedocs.io
 section: colormaps and styles

--- a/packages/cmcrameri.yml
+++ b/packages/cmcrameri.yml
@@ -1,3 +1,4 @@
+name: cmcrameri
 repo: callumrollo/cmcrameri
 section: colormaps and styles
 description: Fabio Crameri's perceptually uniform colormaps for geosciences.

--- a/packages/cmocean.yml
+++ b/packages/cmocean.yml
@@ -1,3 +1,4 @@
+name: cmocean
 repo: matplotlib/cmocean
 site: https://matplotlib.org/cmocean/
 keywords: [styles, palettes, colormaps]

--- a/packages/cmyt.yml
+++ b/packages/cmyt.yml
@@ -1,3 +1,4 @@
+name: cmyt
 repo: yt-project/cmyt
 section: colormaps and styles
 description: Colormaps from the yt project.

--- a/packages/colorcet.yml
+++ b/packages/colorcet.yml
@@ -1,3 +1,4 @@
+name: Colorcet
 repo: holoviz/colorcet
 section: colormaps and styles
 description: Perceptually uniform continuous colormaps and perceptually distinct categorical color sets.

--- a/packages/colorio.yml
+++ b/packages/colorio.yml
@@ -1,3 +1,4 @@
+name: colorio
 repo: nschloe/colorio
 section: domain specific libraries
 description: Tools for working with colors and color spaces.

--- a/packages/cplot.yml
+++ b/packages/cplot.yml
@@ -1,3 +1,4 @@
+name: cplot
 repo: nschloe/cplot
 section: domain specific libraries
 description: Plot complex-valued functions.

--- a/packages/datashader.yml
+++ b/packages/datashader.yml
@@ -1,3 +1,4 @@
+name: Datashader
 repo: holoviz/datashader
 section: plot types
 site: https://datashader.org

--- a/packages/distinctipy.yml
+++ b/packages/distinctipy.yml
@@ -1,3 +1,4 @@
+name: distinctipy
 repo: alan-turing-institute/distinctipy
 section: colormaps and styles
 description: Qualitative colormaps of any length, generated to be maximally distinct.

--- a/packages/eomaps.yml
+++ b/packages/eomaps.yml
@@ -1,3 +1,4 @@
+name: EOmaps
 repo: raphaelquast/eomaps
 section: mapping
 description: A library to create interactive maps of geographical datasets.

--- a/packages/farrow-and-ball.yml
+++ b/packages/farrow-and-ball.yml
@@ -1,3 +1,4 @@
+name: Farrow&Ball Matplotlib
 repo: vork/farrowandball
 section: colormaps and styles
 description: Color palettes inspired by British paint manufacturer Farrow and Ball.

--- a/packages/figpager.yml
+++ b/packages/figpager.yml
@@ -1,3 +1,4 @@
+name: FigPager
 repo: ebenp/figpager
 section: plotting utilities
 description: Save plots with single or multiple pages.

--- a/packages/flexitext.yml
+++ b/packages/flexitext.yml
@@ -1,3 +1,4 @@
+name: Flexitext
 repo: tomicapretto/flexitext
 keywords: ["formatted text", "text styles"]
 section: plotting utilities

--- a/packages/geopandas.yml
+++ b/packages/geopandas.yml
@@ -1,3 +1,4 @@
+name: GeoPandas
 repo: geopandas/geopandas
 section: mapping
 site: https://geopandas.org

--- a/packages/geoplot.yml
+++ b/packages/geoplot.yml
@@ -1,3 +1,4 @@
+name: geoplot
 repo: residentmario/geoplot
 site: https://residentmario.github.io/geoplot/index.html
 keywords: [mapping, geospatial]

--- a/packages/geoviews.yml
+++ b/packages/geoviews.yml
@@ -1,3 +1,4 @@
+name: GeoViews
 repo: holoviz/geoviews
 section: mapping
 site: https://geoviews.org

--- a/packages/gif.yml
+++ b/packages/gif.yml
@@ -1,3 +1,4 @@
+name: gif
 repo: maxhumber/gif
 keywords: [animations]
 section: animations

--- a/packages/glue.yml
+++ b/packages/glue.yml
@@ -1,3 +1,4 @@
+name: Glue
 repo: glue-viz/glue
 section: gui applications
 site: http://docs.glueviz.org

--- a/packages/gr.yml
+++ b/packages/gr.yml
@@ -1,3 +1,4 @@
+name: gr
 repo: jheinen/gr
 section: backends
 description: Graphic kernel system backend.

--- a/packages/grid-strategy.yml
+++ b/packages/grid-strategy.yml
@@ -1,3 +1,4 @@
+name: grid-strategy
 repo: matplotlib/grid-strategy
 section: plotting utilities
 description: Create a grid of subplots based on the number of axes to be plotted.

--- a/packages/grplot.yml
+++ b/packages/grplot.yml
@@ -1,3 +1,4 @@
+name: grplot
 repo: 'ghiffaryr/grplot'
 section: 'domain specific libraries'
 description: 'Complete and attractive statistical graphs in one function.'

--- a/packages/highlight_text.yml
+++ b/packages/highlight_text.yml
@@ -1,3 +1,4 @@
+name: HighlightText
 repo: znstrider/highlight_text
 keywords: ["text handling", annotations]
 section: plotting utilities

--- a/packages/hockey_rink.yml
+++ b/packages/hockey_rink.yml
@@ -1,3 +1,4 @@
+name: Hockey Rink
 repo: the-bucketless/hockey_rink
 site: https://github.com/the-bucketless/hockey_rink
 section: domain specific libraries

--- a/packages/holoviews.yml
+++ b/packages/holoviews.yml
@@ -1,3 +1,4 @@
+name: HoloViews
 repo: holoviz/holoviews
 section: alternative apis
 site: https://holoviews.org

--- a/packages/hvplot.yml
+++ b/packages/hvplot.yml
@@ -1,3 +1,4 @@
+name: hvPlot
 repo: holoviz/hvplot
 section: alternative apis
 site: https://hvplot.holoviz.org

--- a/packages/librosa.yml
+++ b/packages/librosa.yml
@@ -1,3 +1,4 @@
+name: librosa
 repo: librosa/librosa
 section: domain specific libraries
 description: Audio signal processing with waveform and spectrogram displays

--- a/packages/lumen.yml
+++ b/packages/lumen.yml
@@ -1,3 +1,4 @@
+name: Lumen
 repo: holoviz/lumen
 section: gui applications
 site: https://lumen.holoviz.org

--- a/packages/matplotcheck.yml
+++ b/packages/matplotcheck.yml
@@ -1,3 +1,4 @@
+name: matplotcheck
 repo: earthlab/matplotcheck
 section: miscellaneous
 description: A package designed to test matplotlib plots.

--- a/packages/matplotlib-scalebar.yml
+++ b/packages/matplotlib-scalebar.yml
@@ -1,3 +1,4 @@
+name: matplotlib-scalebar
 repo: ppinard/matplotlib-scalebar
 section: plotting utilities
 description: Display a scale bar.

--- a/packages/matplotlib-venn.yml
+++ b/packages/matplotlib-venn.yml
@@ -1,3 +1,4 @@
+name: matplotlib-venn
 repo: konstantint/matplotlib-venn
 keywords: [diagrams, categories, sets]
 section: plot types

--- a/packages/matplotview.yml
+++ b/packages/matplotview.yml
@@ -1,3 +1,4 @@
+name: matplotview
 repo: matplotlib/matplotview
 section: plotting utilities
 description: A library for creating lightweight views of matplotlib axes.

--- a/packages/matplotx.yml
+++ b/packages/matplotx.yml
@@ -1,3 +1,4 @@
+name: matplotx
 repo: nschloe/matplotx
 section: miscellaneous
 description: Useful styles and extensions for Matplotlib.

--- a/packages/metpy.yml
+++ b/packages/metpy.yml
@@ -1,3 +1,4 @@
+name: MetPy
 repo: Unidata/MetPy
 site: https://unidata.github.io/MetPy
 section: domain specific libraries

--- a/packages/microfilm.yml
+++ b/packages/microfilm.yml
@@ -1,3 +1,4 @@
+name: microfilm
 repo: guiwitz/microfilm
 section: domain specific libraries
 description: 2D image plots and animations for multi-channel microscopy data.

--- a/packages/mir-eval.yml
+++ b/packages/mir-eval.yml
@@ -1,3 +1,4 @@
+name: mir_eval
 repo: craffel/mir_eval
 section: domain specific libraries
 description: Evaluation tools and display helpers for audio annotations

--- a/packages/mpl-draggable-line.yml
+++ b/packages/mpl-draggable-line.yml
@@ -1,3 +1,4 @@
+name: mpl-draggable-line
 repo: ianhi/mpl-draggable-line
 keywords: widget, draggable, draggable-line
 section: interactivity

--- a/packages/mpl-gui.yml
+++ b/packages/mpl-gui.yml
@@ -1,4 +1,5 @@
+name: mpl-gui
 repo: tacaswell/mpl-gui
 section: experimental
 description: Prototype for a pyplot alternative
-site: https://tacaswell.github.io/mpl-gui/
+site: https://matplotlib.org/mpl-gui/

--- a/packages/mpl-image-labeller.yml
+++ b/packages/mpl-image-labeller.yml
@@ -1,3 +1,4 @@
+name: mpl-image-labeller
 repo: ianhi/mpl-image-labeller
 keywords: image, classification, label, labeler, labeller
 section: interactivity

--- a/packages/mpl-multitab.yml
+++ b/packages/mpl-multitab.yml
@@ -1,3 +1,4 @@
+name: mpl-multitab
 repo: astromancer/mpl-multitab
 section: gui applications
 description: Tabbed figure manager for matplotlib using pyQt.

--- a/packages/mpl-point-clicker.yml
+++ b/packages/mpl-point-clicker.yml
@@ -1,3 +1,4 @@
+name: mpl_point_clicker
 repo: ianhi/mpl-point-clicker
 keywords: [widgets]
 section: interactivity

--- a/packages/mpl-probscale.yml
+++ b/packages/mpl-probscale.yml
@@ -1,3 +1,4 @@
+name: mpl-probscale
 repo: matplotlib/mpl-probscale
 site: https://matplotlib.org/mpl-probscale/
 keywords: [scales, probability, axes]

--- a/packages/mpl-qtthread.yml
+++ b/packages/mpl-qtthread.yml
@@ -1,3 +1,4 @@
+name: mpl-qtthread
 repo: tacaswell/mpl-qtthread
 section: experimental
 description: Prototype for an approximatly thread-safe Qt backend

--- a/packages/mpl-scatter-density.yml
+++ b/packages/mpl-scatter-density.yml
@@ -1,3 +1,4 @@
+name: mpl-scatter-density
 repo: astrofrog/mpl-scatter-density
 section: plot types
 description: 2D histograms for large collections of point data.

--- a/packages/mpl-table.yml
+++ b/packages/mpl-table.yml
@@ -1,3 +1,4 @@
+name: MPL Table
 repo: geo7/mpl_table
 site: https://github.com/geo7/mpl_table
 keywords: [table, tables, custom, formatting]

--- a/packages/mpl-template.yml
+++ b/packages/mpl-template.yml
@@ -1,3 +1,4 @@
+name: mpl-template
 repo: austinorr/mpl-template
 section: plotting utilities
 description: Templating engine for consistent plots.

--- a/packages/mpl-widget-box.yaml
+++ b/packages/mpl-widget-box.yaml
@@ -1,3 +1,4 @@
+name: mpl_widget_box
 repo: leejjoon/mpl_widget_box
 keywords: [widgets]
 section: interactivity

--- a/packages/mpl_interactions.yml
+++ b/packages/mpl_interactions.yml
@@ -1,3 +1,4 @@
+name: mpl-interactions
 repo: ianhi/mpl-interactions
 keywords: [widgets]
 section: interactivity

--- a/packages/mplcairo.yml
+++ b/packages/mplcairo.yml
@@ -1,3 +1,4 @@
+name: mplcairo
 repo: matplotlib/mplcairo
 section: backends
 description: Improved backend for cairo.

--- a/packages/mplcursors.yml
+++ b/packages/mplcursors.yml
@@ -1,3 +1,4 @@
+name: mplcursors
 repo: anntzer/mplcursors
 keywords: [cursors]
 section: interactivity

--- a/packages/mplcyberpunk.yml
+++ b/packages/mplcyberpunk.yml
@@ -1,3 +1,4 @@
+name: mplcyberpunk
 repo: dhaitz/mplcyberpunk
 keywords: [styles, palettes, colormaps]
 section: colormaps and styles

--- a/packages/mpldatacursors.yml
+++ b/packages/mpldatacursors.yml
@@ -1,3 +1,4 @@
+name: mpldatacursor
 repo: joferkington/mpldatacursor
 keywords: [cursors]
 section: interactivity

--- a/packages/mplfinance.yml
+++ b/packages/mplfinance.yml
@@ -1,3 +1,4 @@
+name: mplfinance
 repo: matplotlib/mplfinance
 section: domain specific libraries
 description: Utilities for the visual analysis of financial data.

--- a/packages/mplhep.yml
+++ b/packages/mplhep.yml
@@ -1,3 +1,4 @@
+name: mplhep
 repo: scikit-hep/mplhep
 section: domain specific libraries
 description: Set of helpers for matplotlib to more easily produce plots typically needed in high energy physics.

--- a/packages/mplinorm.yml
+++ b/packages/mplinorm.yml
@@ -1,3 +1,4 @@
+name: mplinorm
 repo: anntzer/mplinorm
 keywords: [images, contrast]
 section: interactivity

--- a/packages/mplsoccer.yml
+++ b/packages/mplsoccer.yml
@@ -1,3 +1,4 @@
+name: mplsoccer
 repo: andrewRowlinson/mplsoccer
 section: domain specific libraries
 description: Plot soccer/football pitches and charts.

--- a/packages/mplstereonet.yml
+++ b/packages/mplstereonet.yml
@@ -1,3 +1,4 @@
+name: mplsteronet
 repo: joferkington/mplstereonet
 section: mapping
 description: Lower-hemisphere equal-area and equal-angle stereonets.

--- a/packages/myforestplot.yml
+++ b/packages/myforestplot.yml
@@ -1,3 +1,4 @@
+name: MyForestPlot
 repo: toshiakiasakura/myforestplot
 section: domain specific libraries
 description: A flexibly customizable Python tool to create a forest plot

--- a/packages/networkx.yml
+++ b/packages/networkx.yml
@@ -1,3 +1,4 @@
+name: NetworkX
 repo: networkx/networkx
 section: domain specific libraries
 site: https://networkx.org

--- a/packages/numpngw.yml
+++ b/packages/numpngw.yml
@@ -1,3 +1,4 @@
+name: numpngw
 repo: WarrenWeckesser/numpngw
 keywords: [animations, PNG]
 section: animations

--- a/packages/pandas.yml
+++ b/packages/pandas.yml
@@ -1,3 +1,4 @@
+name: pandas
 repo: pandas-dev/pandas
 site: https://pandas.pydata.org
 keywords: ["structured data", columnar, tabular, tables]

--- a/packages/panel.yml
+++ b/packages/panel.yml
@@ -1,3 +1,4 @@
+name: Panel
 repo: holoviz/panel
 section: interactivity
 site: https://panel.holoviz.org

--- a/packages/patchworklib.yml
+++ b/packages/patchworklib.yml
@@ -1,3 +1,4 @@
+name: patchworklib
 repo: ponnhide/patchworklib
 site: https://github.com/ponnhide/patchworklib
 section: plotting utilities

--- a/packages/planetmagfields.yml
+++ b/packages/planetmagfields.yml
@@ -1,3 +1,4 @@
+name: planetMagFields
 repo: AnkitBarik/planetMagFields
 section: domain specific libraries
 keywords: ["magnetic field", "planetary science", "solar system"]

--- a/packages/plotnine.yml
+++ b/packages/plotnine.yml
@@ -1,3 +1,4 @@
+name: plotnine
 repo: has2k1/plotnine
 section: alternative apis
 description: A grammar of graphics for Python.

--- a/packages/plottable.yml
+++ b/packages/plottable.yml
@@ -1,3 +1,4 @@
+name: plottable
 repo: znstrider/plottable
 section: plot types
 description: Beautifully customized tables with matplotlib.

--- a/packages/prettymaps.yml
+++ b/packages/prettymaps.yml
@@ -1,3 +1,4 @@
+name: prettymaps
 repo: marceloprates/prettymaps
 section: mapping
 description: Minimal Python library to draw customized maps from OpenStreetMap data.

--- a/packages/proplot.yml
+++ b/packages/proplot.yml
@@ -1,3 +1,4 @@
+name: ProPlot
 repo: lukelbd/proplot
 site: https://proplot.readthedocs.io/en/latest/
 keywords: [wrapper]

--- a/packages/pyCircos.yml
+++ b/packages/pyCircos.yml
@@ -1,3 +1,4 @@
+name: pyCircos
 repo: ponnhide/pyCircos
 site: https://github.com/ponnhide/pycircos
 section: domain specific libraries

--- a/packages/pyart.yml
+++ b/packages/pyart.yml
@@ -1,3 +1,4 @@
+name: Py-ART
 repo: ARM-DOE/pyart
 section: domain specific libraries
 description: The Python ARM Radar toolkit, used to analyze and plot weather radar data.

--- a/packages/pygenomeviz.yml
+++ b/packages/pygenomeviz.yml
@@ -1,3 +1,4 @@
+name: pyGenomeViz
 repo: moshi4/pyGenomeViz
 section: domain specific libraries
 description: A genome visualization python package for comparative genomics

--- a/packages/pylustrator.yml
+++ b/packages/pylustrator.yml
@@ -1,3 +1,4 @@
+name: Pylustrator
 repo: rgerum/pylustrator
 site: https://pylustrator.readthedocs.io
 keywords: [interactive, GUI, code generation]

--- a/packages/pymatviz.yml
+++ b/packages/pymatviz.yml
@@ -1,3 +1,4 @@
+name: pymatviz
 repo: janosh/pymatviz
 section: domain specific libraries
 description: A toolkit for visualizations in materials informatics.

--- a/packages/pyplutchik.yml
+++ b/packages/pyplutchik.yml
@@ -1,3 +1,4 @@
+name: PyPlutchik
 repo: matplotlib/pyplutchik
 section: domain specific libraries
 description: Python visualisation for Plutchik annotated corpora.

--- a/packages/pyupset.yml
+++ b/packages/pyupset.yml
@@ -1,3 +1,4 @@
+name: PyUpSet
 repo: ImSoErgodic/py-upset
 section: plot types
 description: UpSet suite of visualization methods.

--- a/packages/ridge_map.yml
+++ b/packages/ridge_map.yml
@@ -1,3 +1,4 @@
+name: ridge_map
 repo: ColCarroll/ridge_map
 keywords: [mapping]
 section: mapping

--- a/packages/seaborn-image.yml
+++ b/packages/seaborn-image.yml
@@ -1,3 +1,4 @@
+name: seaborn-image
 repo: SarthakJariwala/seaborn-image
 section: domain specific libraries
 description: High-level API for drawing informative and attractive images.

--- a/packages/seaborn.yml
+++ b/packages/seaborn.yml
@@ -1,3 +1,4 @@
+name: seaborn
 repo: mwaskom/seaborn
 section: domain specific libraries
 description: High-level interface for drawing attractive statistical graphics.

--- a/packages/skunk.yml
+++ b/packages/skunk.yml
@@ -1,3 +1,4 @@
+name: skunk
 repo: whitead/skunk
 section: plotting utilities
 description: Insert SVG images into matplotlib elements. Can be used to also compose matplotlib plots by nesting them.

--- a/packages/sphinx-gallery.yml
+++ b/packages/sphinx-gallery.yml
@@ -1,3 +1,4 @@
+name: Sphinx-Gallery
 repo: sphinx-gallery/sphinx-gallery
 section: documentation
 description: Create matplotlib galleries for your sphinx-built documentation.

--- a/packages/svgpath2mpl.yml
+++ b/packages/svgpath2mpl.yml
@@ -1,3 +1,4 @@
+name: svgpath2mpl
 repo: nvictus/svgpath2mpl
 section: plotting utilities
 description: Parse SVG paths into Matplotlib Path objects for plotting.

--- a/packages/sview-gui.yml
+++ b/packages/sview-gui.yml
@@ -1,3 +1,4 @@
+name: sview-gui
 repo: SojiroFukuda/sview-gui
 section: gui applications
 description: PyQt5 GUI for data visualisation of CSV file or pandas DataFrames.

--- a/packages/tikzplotlib.yml
+++ b/packages/tikzplotlib.yml
@@ -1,3 +1,4 @@
+name: tikzplotlib
 repo: nschloe/tikzplotlib
 keywords: [latex, tikz]
 section: plotting utilities

--- a/packages/tueplots.yml
+++ b/packages/tueplots.yml
@@ -1,3 +1,4 @@
+name: TUEplots
 repo: pnkraemer/tueplots
 section: colormaps and styles
 description: Light-weight matplotlib styles for figures used in scientific publications.

--- a/packages/viscm.yml
+++ b/packages/viscm.yml
@@ -1,3 +1,4 @@
+name: viscm
 repo: matplotlib/viscm
 section: colormaps and styles
 description: Tool for analyzing colormaps and creating new colormaps.

--- a/packages/windrose.yml
+++ b/packages/windrose.yml
@@ -1,3 +1,4 @@
+name: Windrose
 repo: python-windrose/windrose
 section: plot types
 description: Create windrose plots.

--- a/packages/wxmplot.yml
+++ b/packages/wxmplot.yml
@@ -1,3 +1,4 @@
+name: wxmplot
 repo: newville/wxmplot
 section: backends
 description: Tighter integration with wxPython.

--- a/packages/xarray.yml
+++ b/packages/xarray.yml
@@ -1,3 +1,4 @@
+name: Xarray
 repo: pydata/xarray
 site: https://xarray.pydata.org
 keywords: ["structured data", "multi-dimensional arrays", "nD arrays"]

--- a/packages/xmovie.yml
+++ b/packages/xmovie.yml
@@ -1,3 +1,4 @@
+name: xmovie
 repo: jbusecke/xmovie
 section: animations
 description: A simple way of creating beautiful movies from xarray objects.

--- a/packages/yellowbrick.yml
+++ b/packages/yellowbrick.yml
@@ -1,3 +1,4 @@
+name: Yellowbrick
 repo: DistrictDataLabs/yellowbrick
 section: domain specific libraries
 site: https://www.scikit-yb.org

--- a/packages/yt.yml
+++ b/packages/yt.yml
@@ -1,3 +1,4 @@
+name: yt
 repo: yt-project/yt
 site: https://yt-project.org
 keywords: [volumetric]

--- a/python/build.py
+++ b/python/build.py
@@ -66,12 +66,12 @@ for section in config:
     for package in section['packages']:
         print(f"  {package['repo']}")
         try:
-            package['user'], package['name'] = package['repo'].split('/')
+            package['user'], package['repo_name'] = package['repo'].split('/')
         except:
             raise Warning('Package.repo is not in correct format', package)
             continue
-        package['conda_package'] = package.get('conda_package', package['name'])
-        package['pypi_name'] = package.get('pypi_name', package['name'])
+        package['conda_package'] = package.get('conda_package', package['repo_name'])
+        package['pypi_name'] = package.get('pypi_name', package['repo_name'])
 
         package['section'] = section_names[package['section'].lower()]
         if package.get('badges'):
@@ -117,11 +117,11 @@ for section in config:
         
 
         if 'rtd' in package['badges'] and 'rtd_name' not in package:
-            package['rtd_name'] = package['name']
+            package['rtd_name'] = package['repo_name']
 
         if 'site' in package['badges']:
             if 'site' not in package:
-                package['site'] = '{}.org'.format(package['name'])
+                package['site'] = '{}.org'.format(package['repo_name'])
                 package['site_protocol'] = 'https'
             else:
                 package['site_protocol'], package['site'] = package['site'].rstrip('/').split('://')

--- a/python/conda_downloads.py
+++ b/python/conda_downloads.py
@@ -70,12 +70,12 @@ for section in config:
     print(f"Building conda downloads badge for: {section['name']}")
     for package in section['packages']:
         try:
-            package['user'], package['name'] = package['repo'].split('/')
+            package['user'], package['repo_name'] = package['repo'].split('/')
         except:
             raise Warning('Package.repo is not in correct format', package)
             continue
-        url = get_conda_badge(package.get('conda_package', package['name']))
+        url = get_conda_badge(package.get('conda_package', package['repo_name']))
         rendered_url = url
         r = requests.get(rendered_url)
-        badge = (cache_path / f"{package['name']}_conda_downloads_badge.svg")
+        badge = (cache_path / f"{package['repo_name']}_conda_downloads_badge.svg")
         badge.write_bytes(r.content)

--- a/python/template.rst
+++ b/python/template.rst
@@ -18,7 +18,7 @@
       <tr>
         
         <td>
-          <a href="https://github.com/{{ package.user }}/{{ package.name }}">  
+          <a href="https://github.com/{{ package.repo }}">
             <img src="_static/badges/github-gray.svg">
           </a>
         </td>


### PR DESCRIPTION
This:

- save us from having to figure out the project name from a repository location, which will become more complicated when we accept non-GitHub repos (#100).
- allows using whitespace and arbitrary capitalization in the project name (which might be spelled differently than the repository name).
