### PR TITLE
Update to mpl-sphinx-theme 3.7

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -1,6 +1,11 @@
+---
+name: "CircleCI artifact handling"
 on: [status]
 jobs:
   circleci_artifacts_redirector_job:
+    if: "${{ github.event.context == 'ci/circleci: build_docs' }}"
+    permissions:
+      statuses: write
     runs-on: ubuntu-latest
     name: Run CircleCI artifacts redirector
     steps:
@@ -10,3 +15,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-path: 0/docs/build/html/index.html
           circleci-jobs: build_docs
+          job-title: View the built docs

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,3 +1,4 @@
+---
 name: GitHub Pages
 
 on:
@@ -25,7 +26,7 @@ jobs:
 
       - name: Make docs builds
         run: |
-          make -C docs html
+          make -C docs html O="-t release"
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ jinja2
 markdown
 pyyaml
 sphinx
-mpl-sphinx-theme~=3.6.0
+mpl-sphinx-theme~=3.7.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,7 @@ exclude_patterns = []
 html_theme = "mpl_sphinx_theme"
 html_static_path = ["./_static"]
 html_theme_options = {
-    "navbar_links": "server-stable",
+    "navbar_links": ("absolute", "server-stable"),
     "secondary_sidebar_items": "page-toc.html",
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,13 +16,8 @@ exclude_patterns = []
 html_theme = "mpl_sphinx_theme"
 html_static_path = ["./_static"]
 html_theme_options = {
-    "logo": {
-        "link": "https://matplotlib.org/stable",
-        "image_light": "images/logo2.svg",
-        "image_dark": "images/logo_dark.svg",
-    },
-    "navbar_links": "internal",
-    "page_sidebar_items": "page-toc.html",
+    "navbar_links": "server-stable",
+    "secondary_sidebar_items": "page-toc.html",
 }
 
 html_css_files = [

--- a/python/template.rst
+++ b/python/template.rst
@@ -8,7 +8,7 @@
         {% with section_id = section.name | lower | replace(" ", "-") %}
         <h3 id="{{ section_id }}">
           {{ section.name }}
-          <a class="headerlink" href="#{{ section_id }}" title="Permalink to this headline">¶</a>
+          <a class="headerlink" href="#{{ section_id }}" title="Permalink to this headline">#</a>
         </h3>
         {% endwith %}
       </th>


### PR DESCRIPTION
## PR Summary

The logo is currently broken since the build is with latest Sphinx. And the navbar links are broken because they are relative to the project instead of the server.

This will need an actual release of `mpl-sphinx-theme` with the fixes for latest `pydata-sphinx-theme` in order to work.