### PR TITLE
Cleanup parts of the template

### DIFF
--- a/python/build.py
+++ b/python/build.py
@@ -121,10 +121,9 @@ for section in config:
 
         if 'site' in package['badges']:
             if 'site' not in package:
-                package['site'] = '{}.org'.format(package['repo_name'])
-                package['site_protocol'] = 'https'
+                package['site'] = f'https://{package["repo_name"]}.org'
             else:
-                package['site_protocol'], package['site'] = package['site'].rstrip('/').split('://')
+                package['site'] = package['site'].rstrip('/')
 
 template = Template((here / 'template.rst').read_text())
 

--- a/python/build.py
+++ b/python/build.py
@@ -125,7 +125,8 @@ for section in config:
             else:
                 package['site'] = package['site'].rstrip('/')
 
-template = Template((here / 'template.rst').read_text())
+template = Template((here / 'template.rst').read_text(),
+                    lstrip_blocks=True, trim_blocks=True)
 
 config = sorted(config, key = lambda i: i['name'])
 

--- a/python/template.rst
+++ b/python/template.rst
@@ -39,7 +39,7 @@
 
         <td>
         {% if 'site' in package.badges %}
-          <a href="{{ package.site_protocol}}://{{ package.site }}">{{ package.name }}</a>
+          <a href="{{ package.site }}">{{ package.name }}</a>
         {% else %}
           <a href="https://github.com/{{ package.repo }}">{{ package.name }}</a>
         {% endif %}

--- a/python/template.rst
+++ b/python/template.rst
@@ -1,22 +1,21 @@
 .. raw:: html
 
   <div>
-  <table id="packages">
-  {% for section in config %}
-    <tr>
-      <th colspan=5>
-        {% with section_id = section.name | lower | replace(" ", "-") %}
-        <h3 id="{{ section_id }}">
-          {{ section.name }}
-          <a class="headerlink" href="#{{ section_id }}" title="Permalink to this headline">#</a>
-        </h3>
-        {% endwith %}
-      </th>
-    </tr>
+    <table id="packages">
+      {% for section in config %}
+      <tr>
+        <th colspan=5>
+          {% with section_id = section.name | lower | replace(" ", "-") %}
+          <h3 id="{{ section_id }}">
+            {{ section.name }}
+            <a class="headerlink" href="#{{ section_id }}" title="Permalink to this headline">#</a>
+          </h3>
+          {% endwith %}
+        </th>
+      </tr>
 
       {% for package in section.packages %}
       <tr>
-        
         <td>
           <a href="https://github.com/{{ package.repo }}">
             <img src="_static/badges/github-gray.svg">
@@ -36,22 +35,21 @@
           <img src="_static/badges/conda-blue.svg">
           </a>
         {% endif %}
-        </td>        
+        </td>
 
-      <td>
-      {% if 'site' in package.badges %} 
-        <a href="{{ package.site_protocol}}://{{ package.site }}">{{ package.name }}</a>
-      {% else %}
-        <a href="https://github.com/{{ package.repo }}">{{ package.name }}</a>
-      {% endif %}
-      </td>
-      <td>
-        {{ package.description }}   
-      </td>             
-      
+        <td>
+        {% if 'site' in package.badges %}
+          <a href="{{ package.site_protocol}}://{{ package.site }}">{{ package.name }}</a>
+        {% else %}
+          <a href="https://github.com/{{ package.repo }}">{{ package.name }}</a>
+        {% endif %}
+        </td>
+        <td>
+          {{ package.description }}
+        </td>
 
       </tr>
       {% endfor %}
-    {% endfor %}
+      {% endfor %}
     </table>
-    </div>
+  </div>


### PR DESCRIPTION
## PR Summary

This cleans up the indent in the template, removes `site_protocol` in favour of just specifying the `site` URL in its entirety, and enables Jinja2's recommended trimming options so that the resulting HTML doesn't contain a bunch of empty (or whitespace only) lines.