### PR TITLE
Transparent badge background

### DIFF
--- a/python/template.rst
+++ b/python/template.rst
@@ -18,21 +18,21 @@
       <tr>
         <td>
           <a href="{{ package.repo }}">
-            <img src="_static/badges/code-gray.svg" alt="code badge">
+            <img src="_static/badges/code-gray.svg" alt="code badge" class="sd-bg-transparent">
           </a>
         </td>
 
         <td>
         {% if 'pypi' in package.badges %}
           <a href="https://pypi.org/project/{{ package.pypi_name }}">
-            <img src="_static/badges/pip-orange.svg" alt="pypi badge">
+            <img src="_static/badges/pip-orange.svg" alt="pypi badge" class="sd-bg-transparent">
           </a>
         {% endif %}
         </td>
         <td>
         {% if 'conda' in package.badges %}
           <a href="https://anaconda.org/{{ package.conda_channel }}/{{ package.conda_package }}">
-          <img src="_static/badges/conda-blue.svg" alt="conda badge">
+          <img src="_static/badges/conda-blue.svg" alt="conda badge" class="sd-bg-transparent">
           </a>
         {% endif %}
         </td>


### PR DESCRIPTION
In the dark theme view, the badges currently display some light contrast at the edges, in particular at the corners. This can be fixed by setting ` class="sd-bg-transparent"`.