### PR TITLE
ADD: Add cmweather to matplotlib 3rd party packages

### DIFF
--- a/packages/cmweather.yml
+++ b/packages/cmweather.yml
@@ -1,0 +1,6 @@
+name: cmweather
+repo: openradar/cmweather
+site: https://cmweather.readthedocs.io
+keywords: [styles, palettes, colormaps]
+section: colormaps and styles
+description: Perceptually uniform and other colormaps for weather/climate variables.


### PR DESCRIPTION
## PR Summary
Add cmweather to the list of mpl-third-party packages, which was used in a recent publication in the Bulletin of the American Meteorological Society.
