### PR TITLE
add pypalettes .yml file

### DIFF
--- a/packages/pypalettes.yml
+++ b/packages/pypalettes.yml
@@ -1,6 +1,6 @@
 name: pypalettes
 repo: JosephBARBIERDARNAL/pypalettes
 section: colormaps and styles
-description: Large (+2500) collection of colormaps. 
+description: Large (+2500) collection of colormaps.
 site: https://python-graph-gallery.com/color-palette-finder/
 keywords: [colormaps, styles]

--- a/packages/pypalettes.yml
+++ b/packages/pypalettes.yml
@@ -1,6 +1,6 @@
 name: pypalettes
 repo: JosephBARBIERDARNAL/pypalettes
 section: colormaps and styles
-description: Large (+2500) collection of colormaps.
+description: Large (+2500) collection of colormaps. 
 site: https://python-graph-gallery.com/color-palette-finder/
 keywords: [colormaps, styles]

--- a/packages/pypalettes.yml
+++ b/packages/pypalettes.yml
@@ -1,6 +1,6 @@
 name: pypalettes
 repo: JosephBARBIERDARNAL/pypalettes
 section: colormaps and styles
-description: Large collection of colormaps.
+description: Large (+2500) collection of colormaps.
 site: https://python-graph-gallery.com/color-palette-finder/
 keywords: [colormaps, styles]

--- a/packages/pypalettes.yml
+++ b/packages/pypalettes.yml
@@ -1,0 +1,6 @@
+name: pypalettes
+repo: JosephBARBIERDARNAL/pypalettes
+section: colormaps and styles
+description: Large collection of colormaps.
+site: https://python-graph-gallery.com/color-palette-finder/
+keywords: [colormaps, styles]


### PR DESCRIPTION
Hello!

Coming from [this tweet](https://x.com/matplotlib/status/1805620420927709227) for adding the [pypalettes](https://github.com/JosephBARBIERDARNAL/pypalettes) third party.


In this PR, I created pypalettes.yml, with:

```yml
name: pypalettes
repo: JosephBARBIERDARNAL/pypalettes
section: colormaps and styles
description: Large collection of colormaps.
site: https://python-graph-gallery.com/color-palette-finder/
keywords: [colormaps, styles]
```

do I need to do something else?