### PR TITLE
Add kivy_matplotlib_widget as a domain-specific library.

### DIFF
--- a/packages/kivy_matplotlib_widget.yml
+++ b/packages/kivy_matplotlib_widget.yml
@@ -1,0 +1,5 @@
+name: kivy_matplotlib_widget
+repo: mp-007/kivy_matplotlib_widget
+keywords: [interactive graph, cursor]
+section: Interactivity
+description: Convert your matplotlib graph into full interactive graph.


### PR DESCRIPTION
## PR Summary

Add kivy_matplotlib_widget as a domain-specific library.
