### PR TITLE
Added IDE section

### DIFF
--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,24 @@
+pushd %~dp0
+
+REM Minimal windows makefile for sphinx documentation
+
+
+set SPHINXOPTS=
+set SPHINXBUILD=python -msphinx
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+if "%1" == "show" goto show
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:show
+python -m webbrowser -t "%~dp0\build\html\index.html"
+
+:end

--- a/packages/jupyterLab.yml
+++ b/packages/jupyterLab.yml
@@ -1,0 +1,9 @@
+name: JupyterLab
+repo: jupyterlab/jupyterlab
+section: ides
+description: >-
+  Web-based interactive development environment for notebooks, code, and data.
+site: https://jupyterlab.readthedocs.io/en/stable/ # optional, default repo site
+keywords: [ides, interactive] # optional
+pypi_name: jupyterlab
+conda_package: jupyterlab

--- a/packages/jupyterNotebook.yml
+++ b/packages/jupyterNotebook.yml
@@ -1,0 +1,9 @@
+name: Jupyter Notebook
+repo: jupyter/notebook
+section: ides
+description: >-
+  Web-based interactive development environment for notebooks, code, and data.
+site: https://jupyter-notebook.readthedocs.io/en/stable/ # optional, default repo site
+keywords: [ides, interactive] # optional
+pypi_name: notebook
+conda_package: notebook

--- a/packages/pycharm.yml
+++ b/packages/pycharm.yml
@@ -1,0 +1,6 @@
+name: pycharm
+repo: https://www.jetbrains.com/pycharm/
+section: ides
+description: Python IDE for data science and web development.
+site: https://www.jetbrains.com/pycharm/ # optional, default repo site
+keywords: [ide, interactivity] # optional

--- a/packages/spyder.yml
+++ b/packages/spyder.yml
@@ -1,0 +1,8 @@
+name: spyder
+repo: spyder-ide/spyder
+section: ides
+description: >-
+  Open source, community-developed scientific environment and IDE written in Python,
+  for Python.
+site: https://www.spyder-ide.org/ # optional, default repo site
+keywords: [ides, interactivity]

--- a/packages/vscode.yml
+++ b/packages/vscode.yml
@@ -1,0 +1,8 @@
+name: vscode
+repo: microsoft/vscode
+section: ides
+description: >-
+  Streamlined code editor with support for development operations like debugging,
+  task running, and version control.
+site: https://code.visualstudio.com/
+keywords: [ides, interactivity]

--- a/section_names.yml
+++ b/section_names.yml
@@ -11,4 +11,5 @@ section_names:
   domain specific libraries: Domain-specific libraries
   documentation: Documentation
   experimental: Experimental projects that may be merged upstream eventually
+  ides: Development tools with built-in Matplotlib rendering
   miscellaneous: Miscellaneous


### PR DESCRIPTION
## PR Summary

Added a new section for IDEs that have built in interactive backends, based on discussion in https://github.com/matplotlib/matplotlib/pull/29055 

This lets new IDES (like marimo) self register and means we don't have to maintain/update the list in docs. Follow up would be to pull those sections out of https://matplotlib.org/devdocs/users/explain/figure/interactive.html and replace with a link to here. 