### PR TITLE
Dataclocklib third party package addition

### DIFF
--- a/packages/dataclocklib.yml
+++ b/packages/dataclocklib.yml
@@ -1,0 +1,7 @@
+name: dataclocklib
+repo: https://github.com/andyrids/dataclocklib
+section: plot types
+description: Data clock charts using matplotlib.
+site: https://andyrids.github.io/dataclocklib/
+keywords: [data clock, circle graph, temporal]
+pypi_name: dataclocklib


### PR DESCRIPTION
Package information for dataclocklib has been added. This package allows the user to create data clock graphs, using matplotlib.

- Repo: https://github.com/andyrids/dataclocklib
- Documentation: https://andyrids.github.io/dataclocklib/
