### PR TITLE
add morethemes third party

### DIFF
--- a/packages/morethemes.yml
+++ b/packages/morethemes.yml
@@ -1,0 +1,6 @@
+name: morethemes
+repo: JosephBARBIERDARNAL/morethemes
+section: colormaps and styles
+description: More (polished) themes for Matplotlib.
+site: https://python-graph-gallery.com/color-palette-finder/
+keywords: [styles]

--- a/packages/morethemes.yml
+++ b/packages/morethemes.yml
@@ -2,5 +2,5 @@ name: morethemes
 repo: JosephBARBIERDARNAL/morethemes
 section: colormaps and styles
 description: More (polished) themes for Matplotlib.
-site: https://python-graph-gallery.com/color-palette-finder/
+site: https://josephbarbierdarnal.github.io/morethemes/
 keywords: [styles]


### PR DESCRIPTION
## PR Summary

I added [morethemes](https://github.com/JosephBARBIERDARNAL/morethemes), a package that simply provides themes for matplotlib.
