### PR TITLE
Don't deploy website every day

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 9 * * *'
 
 jobs:
   deploy:
@@ -21,7 +19,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Install documentation requirements
         run: |


### PR DESCRIPTION
Currently the website is being deployed every day (although the deployment is failing at the moment). It should be enough to just deploy on every push to `main`, so remove the CRON schedule.