### PR TITLE
Add break_axes package (issue 11682)

### DIFF
--- a/packages/break_axes.yml
+++ b/packages/break_axes.yml
@@ -1,0 +1,5 @@
+name: break_axes
+repo: wuyao1997/break_axes
+section: plotting utilities
+description: A Matplotlib-based utility module for creating broken axes.
+keywords: [axes]


### PR DESCRIPTION
## PR Summary

break_axes is a Matplotlib-based utility module for creating broken axes.  See [issue 11682](https://github.com/matplotlib/matplotlib/issues/11682)

In this new [break_axes](https://github.com/wuyao1997/break_axes) package, axis scaling and break marker addition are separated into two functions, as these two features are independent. Additionally, a `clip_path` approach is used to create breaks in spines and hide artists in the folded regions of the axes.  

Currently, the implementation of [break_axes](https://github.com/wuyao1997/break_axes) consists of fewer than 900 lines of code, approximately half of which are docstrings. It can currently be installed using the following command:  

```bash
pip install break_axes
```
Multiple Broken Axes
![multi_break.png](https://raw.githubusercontent.com/wuyao1997/break_axes/main/image/multi_break.png)

Log Axes
![logscale_break.png](https://raw.githubusercontent.com/wuyao1997/break_axes/main/image/logscale_break.png)

Even for Contour Plot
<img width="613" height="599" alt="image" src="https://github.com/user-attachments/assets/494966d7-5939-429a-9cc2-87df6a5de87f" />

