### PR TITLE
Add curved-text

### DIFF
--- a/packages/curved-text.yml
+++ b/packages/curved-text.yml
@@ -1,0 +1,5 @@
+name: curved-text
+repo: thiebes/curved-text
+keywords: [text, annotation, labels, curve]
+section: plotting utilities
+description: Draw a string along an arbitrary curve, with arc-length positioning and a perpendicular offset.


### PR DESCRIPTION
Adds [curved-text](https://github.com/thiebes/curved-text), a small library that draws a string along an arbitrary (x, y) curve, one character at a time, with arc-length positioning and a perpendicular offset. The layout is recomputed on every draw, so labels stay glued to the curve through layout, resizing, and interactive pan/zoom. It carries the `Framework :: Matplotlib` classifier and is on PyPI as `curved-text`.